### PR TITLE
Add unit tests for Kafka consumer, producer, and enqueue_json

### DIFF
--- a/tests/test_consumer.py
+++ b/tests/test_consumer.py
@@ -1,0 +1,19 @@
+from kafka import KafkaConsumer
+
+def test_consumer():
+    consumer = KafkaConsumer(
+        'test',
+        bootstrap_servers=['localhost:9092'],
+        auto_offset_reset='earliest',
+        enable_auto_commit=False,
+        value_deserializer=lambda x: x.decode('utf-8')
+    )
+
+    # Verify consumer properties
+    assert consumer.bootstrap_servers == ['localhost:9092']
+    assert consumer.config['auto_offset_reset'] == 'earliest'
+    assert consumer.config['enable_auto_commit'] == False
+
+    # Verify consumer behavior
+    consumer.subscribe(['test'])
+    assert consumer.subscription() == {'test'}

--- a/tests/test_enqueue_json.py
+++ b/tests/test_enqueue_json.py
@@ -1,0 +1,16 @@
+from app.enqueue_json import enqueue_json
+from unittest.mock import MagicMock
+
+def test_enqueue_json():
+    # Create a mock Kafka producer
+    mock_producer = MagicMock()
+    
+    # Replace the producer in the enqueue_json module with the mock producer
+    enqueue_json.producer = mock_producer
+    
+    # Call enqueue_json with sample JSON data
+    sample_json_data = '{"key": "value"}'
+    enqueue_json(sample_json_data)
+    
+    # Verify the producer's behavior
+    mock_producer.send.assert_called_once_with("test", value=sample_json_data.encode("utf-8"))

--- a/tests/test_producer.py
+++ b/tests/test_producer.py
@@ -1,0 +1,15 @@
+from kafka import KafkaProducer
+
+def test_producer():
+    producer = KafkaProducer(
+        bootstrap_servers=["localhost:9092"]
+    )
+
+    # Verify producer properties
+    assert producer.bootstrap_servers == ["localhost:9092"]
+
+    # Verify producer behavior
+    future = producer.send("test", value=b"test message")
+    result = future.get(timeout=10)
+    assert result.topic == "test"
+    assert result.value == b"test message"

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -1,0 +1,31 @@
+import os
+import json
+
+def test_storage():
+    path = os.path.join('app', 'storage', 'test_data.json')
+    with open(path, 'r') as file:
+        json_data = json.load(file)
+    
+    assert isinstance(json_data, dict)
+    assert 'test' in json_data
+    assert 'timestamp' in json_data
+
+    test_data = json_data['test']
+    assert 'msg' in test_data
+    assert 'data' in test_data
+
+    msg_data = test_data['msg']
+    assert isinstance(msg_data, list)
+    assert len(msg_data) == 2
+    assert msg_data[0] == "this is some test message from a JSON file."
+    assert msg_data[1] == "long massage"
+
+    data = test_data['data']
+    assert 'name' in data
+    assert 'age' in data
+    assert 'city' in data
+    assert data['name'] == "John Doe"
+    assert data['age'] == 30
+    assert data['city'] == "New York"
+
+    assert json_data['timestamp'] == 1600000000


### PR DESCRIPTION
Add unit tests for Kafka consumer, producer, enqueue_json function, and storage.

* **tests/test_consumer.py**
  - Import `KafkaConsumer` from `kafka`.
  - Define `test_consumer` function.
  - Create a `KafkaConsumer` instance and verify its properties and behavior.

* **tests/test_enqueue_json.py**
  - Import `enqueue_json` from `app/enqueue_json`.
  - Define `test_enqueue_json` function.
  - Create a mock Kafka producer and verify its behavior when `enqueue_json` is called with sample JSON data.

* **tests/test_producer.py**
  - Import `KafkaProducer` from `kafka`.
  - Define `test_producer` function.
  - Create a `KafkaProducer` instance and verify its properties and behavior.

* **tests/test_storage.py**
  - Import `os` and `json` modules.
  - Define `test_storage` function.
  - Read and verify the contents of `app/storage/test_data.json`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/AyumiOsawa/kafka-test/pull/1?shareId=09d6c83a-6515-46cd-87d3-d6ae206bf0c4).